### PR TITLE
feat: configure HikariCP pool (fix recurring pool-exhaustion outages)

### DIFF
--- a/v2_spring_backend/tdd/src/main/resources/application.properties
+++ b/v2_spring_backend/tdd/src/main/resources/application.properties
@@ -3,6 +3,20 @@ spring.datasource.username=root
 spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 
+# HikariCP connection pool.
+# The pool previously ran on defaults (10 connections, 30s connection-timeout,
+# 30m max-lifetime), which caused recurring pool-exhaustion storms: a few slow
+# queries held all 10 connections and every other request 500ed with
+# "HikariPool-1 - Connection is not available".
+spring.datasource.hikari.maximum-pool-size=30
+spring.datasource.hikari.minimum-idle=5
+# fail fast when the pool is saturated instead of queueing requests for 30s
+spring.datasource.hikari.connection-timeout=10000
+# recycle connections before server/network idle kills them (addresses
+# "PoolBase - Failed to validate connection" warnings); must stay well below
+# MySQL wait_timeout
+spring.datasource.hikari.max-lifetime=580000
+
 spring.profiles.active=local
 
 server.port=1437


### PR DESCRIPTION
## Problem
Analysis of the production BE log (2025-06-01 → 2026-07-13, one process) found **~35k** `HikariPool-1 - Connection is not available, request timed out` errors in recurring storms (worst: 15,924 in 2026-04). During a storm **every** API request 500s.

Mechanism: the pool runs on Spring Boot defaults — **10 connections** total, 30s connection-timeout, 30m max-lifetime — and a handful of slow queries (unfiltered `count(1)` on `tdd_video_record`, big range scans, the now-removed hourly UNION) hold all 10 connections; everything else queues 30s and dies.

## Change (config only)
```properties
spring.datasource.hikari.maximum-pool-size=30   # was default 10
spring.datasource.hikari.minimum-idle=5
spring.datasource.hikari.connection-timeout=10000  # fail fast vs 30s pile-up
spring.datasource.hikari.max-lifetime=580000    # recycle before idle kill; << MySQL wait_timeout
```
Sizing: MySQL `max_connections` is 500; the spider peaks ~200 sessions — 30 for the BE fits comfortably.
`max-lifetime` also addresses the recurring `PoolBase - Failed to validate connection` warnings (connections being killed under the pool).

## Deploy note
Prod runs with an external/profile config for credentials; these `spring.datasource.hikari.*` keys are new (not overridden there), so they take effect from the packaged defaults. Verify after deploy via startup log (`HikariPool-1 - Start completed`) and that hot endpoints respond during spider-heavy hours (e.g. 04:00).

## Follow-up (separate PR)
Guard the unfiltered `/record` `count(1)` full-table scan — the main slow-query source that triggers the storms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)